### PR TITLE
MRHOF improvements

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -162,7 +162,7 @@
  * Initial metric attributed to a link when the ETX is unknown
  */
 #ifndef RPL_CONF_INIT_LINK_METRIC
-#define RPL_INIT_LINK_METRIC        5 * RPL_MIN_HOPRANKINC
+#define RPL_INIT_LINK_METRIC        5
 #else
 #define RPL_INIT_LINK_METRIC        RPL_CONF_INIT_LINK_METRIC
 #endif

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -548,7 +548,7 @@ rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
     p->dag = dag;
     p->rank = dio->rank;
     p->dtsn = dio->dtsn;
-    p->link_metric = RPL_INIT_LINK_METRIC;
+    p->link_metric = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
 #if RPL_DAG_MC != RPL_DAG_MC_NONE
     memcpy(&p->mc, &dio->mc, sizeof(p->mc));
 #endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */


### PR DESCRIPTION
- Cleaned up various fragments and fixed a compilation error that occured when switching metric container.
- Fixed a wrapping problem in the ETX EWMA calculation.
- Corrected the multiplier of the link metric, and simplified the configuration so that the user does not need to specify the multiplier.
