### PR TITLE
Make sure that Coffee updates the file end after a micro log write.

### DIFF
--- a/core/cfs/cfs-coffee.c
+++ b/core/cfs/cfs-coffee.c
@@ -1155,6 +1155,7 @@ cfs_write(int fd, const void *buf, unsigned size)
   int i;
   struct log_param lp;
   cfs_offset_t bytes_left;
+  int8_t need_dummy_write;
   const char dummy[1] = { 0xff };
 #endif
 
@@ -1188,6 +1189,7 @@ cfs_write(int fd, const void *buf, unsigned size)
 #else
   if(FILE_MODIFIED(file) || fdp->offset < file->end) {
 #endif
+    need_dummy_write = 0;
     for(bytes_left = size; bytes_left > 0;) {
       lp.offset = fdp->offset;
       lp.buf = buf;
@@ -1212,13 +1214,19 @@ cfs_write(int fd, const void *buf, unsigned size)
            occur while writing log records. */
         if(fdp->offset > file->end) {
           file->end = fdp->offset;
+          need_dummy_write = 1;
         }
       }
     }
 
-    if(fdp->offset > file->end) {
-      /* Update the original file's end with a dummy write. */
-      COFFEE_WRITE(dummy, 1, absolute_offset(file->page, fdp->offset));
+    if(need_dummy_write) {
+      /*
+       * A log record has been written at an offset beyond the original
+       * extent's end. Consequently, we need to write a dummy value at the
+       * corresponding end offset in the original extent to ensure that
+       * the correct file size is calculated when opening the file again.
+       */
+      COFFEE_WRITE(dummy, 1, absolute_offset(file->page, fdp->offset - 1));
     }
   } else {
 #endif /* COFFEE_MICRO_LOGS */


### PR DESCRIPTION
The file end was not updated in the original file extent after a micro log operation had written beyond it.

This error was discussed in contiki-os/contiki#512.
